### PR TITLE
Add textField.resignFirstResponder to Authenticator Client example

### DIFF
--- a/Examples/Authenticator/Authenticator Client/LoginViewController.swift
+++ b/Examples/Authenticator/Authenticator Client/LoginViewController.swift
@@ -27,7 +27,7 @@ import UIKit
 
 let LOGIN_SEGUE_ID = "loginSegue"
 
-class LoginViewController: UIViewController, NSURLSessionDelegate {
+class LoginViewController: UIViewController, NSURLSessionDelegate, UITextFieldDelegate {
 
 	@IBOutlet var emailAddressText: UITextField?
 	@IBOutlet var passwordText: UITextField?
@@ -38,6 +38,8 @@ class LoginViewController: UIViewController, NSURLSessionDelegate {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
+        self.emailAddressText?.delegate = self
+        self.passwordText?.delegate = self
     }
 
     override func didReceiveMemoryWarning() {
@@ -93,4 +95,9 @@ class LoginViewController: UIViewController, NSURLSessionDelegate {
 		
 		task.resume()
 	}
+
+    func textFieldShouldReturn(textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
 }

--- a/Examples/Authenticator/RegisterViewController.swift
+++ b/Examples/Authenticator/RegisterViewController.swift
@@ -33,7 +33,7 @@ extension String {
 	}
 }
 
-class RegisterViewController: UIViewController {
+class RegisterViewController: UIViewController, UITextFieldDelegate {
 
 	@IBOutlet var firstNameText: UITextField?
 	@IBOutlet var lastNameText: UITextField?
@@ -47,6 +47,11 @@ class RegisterViewController: UIViewController {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
+        self.firstNameText?.delegate = self
+        self.lastNameText?.delegate = self
+        self.emailAddressText?.delegate = self
+        self.password1Text?.delegate = self
+        self.password2Text?.delegate = self
     }
 
     override func didReceiveMemoryWarning() {
@@ -100,4 +105,8 @@ class RegisterViewController: UIViewController {
 		task.resume()
 	}
 
+    func textFieldShouldReturn(textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
 }


### PR DESCRIPTION
I was not able to dismiss the keyboard while pressing the return key at register and login view and I could not register (See images below). So I added dismiss keyboard function at textFieldShouldReturn method.

![img_0188](https://cloud.githubusercontent.com/assets/9270368/11914223/7ce5af48-a6bd-11e5-8623-a7bf63624b9a.PNG)
