### PR TITLE
Added --libpath

### DIFF
--- a/PerfectLib/PerfectServer.swift
+++ b/PerfectLib/PerfectServer.swift
@@ -26,7 +26,7 @@
 /// Standard directory for server-side SQLite support databases
 public let serverSQLiteDBs = "SQLiteDBs/"
 /// Directory for server-size modules. Modules in this directory are loaded at server startup.
-public let serverPerfectLibraries = "PerfectLibraries/"
+public var serverPerfectLibraries = "PerfectLibraries/"
 
 /// Provides access to various system level features for the process.
 /// A static instance of this class is created at startup and all access to this object go through the `PerfectServer.staticPerfectServer` static property.
@@ -49,7 +49,13 @@ public class PerfectServer {
 		}
 		
 		let dl = DynamicLoader()
-		let baseDir = Dir(homeDir() + serverPerfectLibraries)
+        var baseDir : Dir
+        if serverPerfectLibraries.hasPrefix("/") || serverPerfectLibraries.hasPrefix("~/") || serverPerfectLibraries.hasPrefix("./") {
+            baseDir = Dir(serverPerfectLibraries)
+        } else {
+            baseDir = Dir(homeDir() + serverPerfectLibraries)
+        }
+        print("Load libs from: \(baseDir.realPath())");
 		do {
 			try baseDir.forEachEntry { (name: String) -> () in
 				if name.hasSuffix(".framework") || name.hasSuffix(".framework/") {

--- a/PerfectServer/main_fcgi.swift
+++ b/PerfectServer/main_fcgi.swift
@@ -33,7 +33,6 @@ import PerfectLib
 func startServer() throws {
 
 	let ls = PerfectServer.staticPerfectServer
-	ls.initializeServices()
 
 	var sockPath = "./perfect.fastcgi.sock"
 	var args = Process.arguments
@@ -43,9 +42,13 @@ func startServer() throws {
 		"--sockpath": {
 			args.removeFirst()
 			sockPath = args.first!
-		},
+        },
+		"--libpath": {
+            args.removeFirst()
+            serverPerfectLibraries = args.first!
+        },
 		"--help": {
-			print("Usage: \(Process.arguments.first!) [--sockpath socket_path]")
+			print("Usage: \(Process.arguments.first!) [--sockpath socket_path] [--libpath lib_path]")
 			exit(0)
 		}]
 	
@@ -55,7 +58,9 @@ func startServer() throws {
 		}
 		args.removeFirst()
 	}
-	
+    
+    ls.initializeServices()
+    
 	let fastCgiServer = FastCGIServer()
 	try fastCgiServer.start(sockPath)
 }

--- a/PerfectServer/main_http.swift
+++ b/PerfectServer/main_http.swift
@@ -33,7 +33,6 @@ import Darwin
 func startServer() throws {
 	
 	let ls = PerfectServer.staticPerfectServer
-	ls.initializeServices()
 	
 	var webRoot = "./webroot/"
 	var serverName = ""
@@ -68,9 +67,13 @@ func startServer() throws {
 		"--name": {
 			args.removeFirst()
 			serverName = args.first!
-		},
+        },
+		"--libpath": {
+            args.removeFirst()
+            serverPerfectLibraries = args.first!
+        },
 		"--help": {
-			print("Usage: \(Process.arguments.first!) [--port listen_port] [--address listen_address] [--name server_name] [--root root_path] [--sslcert cert_path --sslkey key_path]")
+			print("Usage: \(Process.arguments.first!) [--port listen_port] [--address listen_address] [--name server_name] [--root root_path] [--sslcert cert_path --sslkey key_path] [--libpath lib_path]")
 			exit(0)
 		}]
 	
@@ -80,7 +83,9 @@ func startServer() throws {
 		}
 		args.removeFirst()
 	}
-	
+    
+    ls.initializeServices()
+    
 	try Dir(webRoot).create()
 	let httpServer = HTTPServer(documentRoot: webRoot)
 	httpServer.serverName = serverName


### PR DESCRIPTION
By default server load libs from ./PerfectLibraries. Or designate path
to load libs. For example, run
$ perfectserverhttp --libpath /usr/local/PerfectServer/lib