### PR TITLE
Fix testStringByDeletingLastPathComponent

### DIFF
--- a/PerfectLib/PerfectLibTests/PerfectLibTests.swift
+++ b/PerfectLib/PerfectLibTests/PerfectLibTests.swift
@@ -810,7 +810,7 @@ class PerfectLibTests: XCTestCase {
 	
 	func testStringByDeletingLastPathComponent() {
 		XCTAssert("/a/".stringByDeletingLastPathComponent == "/")
-		XCTAssert("/b/a".stringByDeletingLastPathComponent == "/b/")
+		XCTAssert("/b/a".stringByDeletingLastPathComponent == "/b")
 		XCTAssert("/".stringByDeletingLastPathComponent == "/")
 	}
 	


### PR DESCRIPTION
        XCTAssert("/b/a".stringByDeletingLastPathComponent == "/b/")

changed to

        XCTAssert("/b/a".stringByDeletingLastPathComponent == "/b")