### PR TITLE
Make target for installing Xcode Template

### DIFF
--- a/Extras/Xcode Templates/Perfect/makefile
+++ b/Extras/Xcode Templates/Perfect/makefile
@@ -1,0 +1,3 @@
+install:
+	mkdir -p ~/Library/Developer/Xcode/Templates/Project\ Templates/
+	rsync -rupE Perfect\ Server\ Framework.xctemplate ~/Library/Developer/Xcode/Templates/Project\ Templates/

--- a/makefile
+++ b/makefile
@@ -10,3 +10,6 @@ examples:
 clean:
 	cd PerfectLib && $(MAKE) clean
 	cd PerfectServer && $(MAKE) clean
+
+template:
+	cd Extras/Xcode\ Templates/Perfect && $(MAKE) install


### PR DESCRIPTION
Add a Make target `template` for installing the Xcode Template.
use `make template` to install the `Perfect Server Framework.xctemplate` to `~/Library/Developer/Xcode/Templates/Project\ Templates/`
