### PR TITLE
Fix integer type bug in MySQL Connector

### DIFF
--- a/Connectors/MySQL/MySQL.swift
+++ b/Connectors/MySQL/MySQL.swift
@@ -47,8 +47,6 @@ public enum MySQLOpt {
 		MYSQL_OPT_CAN_HANDLE_EXPIRED_PASSWORDS
 }
 
-let _UNSIGNED_FLAG = UInt32(UNSIGNED_FLAG)
-
 public final class MySQL {
 	
 	static private var dispatchOnce = Threading.ThreadOnce()
@@ -627,6 +625,7 @@ public final class MySQLStmt {
 	}
 	
 	public final class Results: GeneratorType {
+        let _UNSIGNED_FLAG = UInt32(UNSIGNED_FLAG)
 		public typealias Element = [Any?]
 		
 		let stmt: MySQLStmt

--- a/Connectors/MySQL/MySQL.swift
+++ b/Connectors/MySQL/MySQL.swift
@@ -724,11 +724,12 @@ public final class MySQLStmt {
 			return bind
 		}
 		
-        func bindBuffer<T>(var bind: MYSQL_BIND, type: T) -> MYSQL_BIND {
-            bind.buffer = UnsafeMutablePointer<()>(UnsafeMutablePointer<T>.alloc(1))
-            bind.buffer_length = UInt(sizeof(T))
-            return bind
-        }
+		func bindBuffer<T>(sourceBind: MYSQL_BIND, type: T) -> MYSQL_BIND {
+			var bind = sourceBind
+			bind.buffer = UnsafeMutablePointer<()>(UnsafeMutablePointer<T>.alloc(1))
+			bind.buffer_length = UInt(sizeof(T))
+			return bind
+		}
         
 		public func forEachRow(callback: Element -> ()) -> Bool {
 			

--- a/Connectors/MySQL/MySQL.swift
+++ b/Connectors/MySQL/MySQL.swift
@@ -848,7 +848,7 @@ public final class MySQLStmt {
 					return false
 				}
 				
-				var row = [Any?]()
+				var row = Element()
 				
 				for i in 0..<numFields {
 					var bind = binds[i]
@@ -967,14 +967,6 @@ public final class MySQLStmt {
 			case .Null:
 				return bindToNull()
 			}
-		}
-		
-		func bindToDouble() -> MYSQL_BIND {
-			return bindToIntegral(MYSQL_TYPE_DOUBLE)
-		}
-		
-		func bindToInteger() -> MYSQL_BIND {
-			return bindToIntegral(MYSQL_TYPE_LONGLONG)
 		}
 		
 		func bindToBlob() -> MYSQL_BIND {

--- a/Connectors/MySQL/MySQLTests/MySQLTests.swift
+++ b/Connectors/MySQL/MySQLTests/MySQLTests.swift
@@ -24,6 +24,7 @@
 //
 
 import XCTest
+import PerfectLib
 @testable import MySQL
 
 let HOST = "127.0.0.1"
@@ -389,16 +390,11 @@ class MySQLTests: XCTestCase {
 			
 			"BLOB DATA".withCString { p in
 				stmt1.bindParam(p, length: 9)
-				
 				stmt1.bindParam("tiny text string")
-				
 				stmt1.bindParam(p, length: 9)
 				stmt1.bindParam(p, length: 9)
-				
 				stmt1.bindParam("medium text string")
-				
 				stmt1.bindParam(p, length: 9)
-				
 				stmt1.bindParam("long text string")
 				stmt1.bindParam("1")
 				stmt1.bindParam("2")
@@ -429,6 +425,36 @@ class MySQLTests: XCTestCase {
 				print(e.flatMap({ (a:Any?) -> Any? in
 					return a!
 				}))
+                
+                XCTAssertEqual(e[0] as? String, "varchar 20 string 👻")
+                XCTAssertEqual(e[1] as? Int8, 1)
+                XCTAssertEqual(UTF8Encoding.encode(e[2] as! [UInt8]), "text string")
+                XCTAssertEqual(e[3] as? String, "2015-10-21")
+                XCTAssertEqual(e[4] as? Int16, 32767)
+                XCTAssertEqual(e[5] as? Int32, 8388607)
+                XCTAssertEqual(e[6] as? Int32, 2147483647)
+                XCTAssertEqual(e[7] as? Int64, 9223372036854775807)
+                XCTAssertEqual(e[8] as? UInt64, 18446744073709551615 as UInt64)
+                XCTAssertEqual(e[9] as? Float, 1.1)
+                XCTAssertEqual(e[10] as? Double, 1.1)
+                XCTAssertEqual(e[11] as? String, "1.10")
+                XCTAssertEqual(e[12] as? String, "2015-10-21 12:00:00")
+                XCTAssertEqual(e[13] as? String, "2015-10-21 12:00:00")
+                XCTAssertEqual(e[14] as? String, "03:14:07")
+                XCTAssertEqual(e[15] as? String, "2015")
+                XCTAssertEqual(e[16] as? String, "K")
+                XCTAssertEqual(UTF8Encoding.encode(e[17] as! [UInt8]), "BLOB DATA")
+                XCTAssertEqual(UTF8Encoding.encode(e[18] as! [UInt8]), "tiny text string")
+                XCTAssertEqual(UTF8Encoding.encode(e[19] as! [UInt8]), "BLOB DATA")
+                XCTAssertEqual(UTF8Encoding.encode(e[20] as! [UInt8]), "BLOB DATA")
+                XCTAssertEqual(UTF8Encoding.encode(e[21] as! [UInt8]), "medium text string")
+                XCTAssertEqual(UTF8Encoding.encode(e[22] as! [UInt8]), "BLOB DATA")
+                XCTAssertEqual(UTF8Encoding.encode(e[23] as! [UInt8]), "long text string")
+                XCTAssertEqual(e[24] as? String, "1")
+                XCTAssertEqual(e[25] as? String, "2")
+                XCTAssertEqual(e[26] as? Int8, 1)
+                XCTAssertEqual(e[27] as? String, "1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0")
+                XCTAssertEqual(e[28] as? String, "1")
 			}
 			XCTAssert(ok, stmt1.errorMessage())
 			
@@ -745,6 +771,136 @@ class MySQLTests: XCTestCase {
             XCTAssertEqual(row[5] as? String, "-3.3")
         }
     }
+
+    /*
+    try dbManager.query("CREATE TABLE IF NOT EXISTS `all_data_types` (`char` CHAR( 10 ),`varchar` VARCHAR( 20 ),`tinytext` TINYTEXT,`mediumtext` MEDIUMTEXT,`text` TEXT,`longtext` LONGTEXT,"
+    + "`tinyint` TINYINT,`utinyint` TINYINT UNSIGNED,`smallint` SMALLINT,`usmallint` SMALLINT UNSIGNED,`mediumint` MEDIUMINT,`umediumint` MEDIUMINT UNSIGNED,"
+    + "`int` INT,`uint` INT UNSIGNED,`bigint` BIGINT,`ubigint` BIGINT UNSIGNED,"
+    + "`float` FLOAT( 10, 2 ),`double` DOUBLE,`decimal` DECIMAL( 10, 2 ),"
+    + "`date` DATE,`datetime` DATETIME,`timestamp` TIMESTAMP,`time` TIME,`year` YEAR,"
+    + "`tinyblob` TINYBLOB,`mediumblob` MEDIUMBLOB,`blob` BLOB,`longblob` LONGBLOB,"
+    + "`enum` ENUM( '1', '2', '3' ),`set` SET( '1', '2', '3' ),`bool` BOOL,"
+    + "`binary` BINARY( 20 ),`varbinary` VARBINARY( 20 ) )")
+    
+    try dbManager.query("DELETE FROM all_data_types")
+    
+    try dbManager.query("INSERT INTO all_data_types (`char`,`varchar`,`tinytext`,`mediumtext`,`text`,`longtext`,"
+    + "`tinyint`,`utinyint`,`smallint`,`usmallint`,`mediumint`,`umediumint`,"
+    + "`int`,`uint`,`bigint`,`ubigint`,"
+    + "`float`, `double`, `decimal`,"
+    + "`date`, `datetime`, `timestamp`, `time`,`year`,"
+    + "`tinyblob`, `mediumblob`, `blob`,`longblob`,"
+    + "`enum`,`set`,`bool`,"
+    + "`binary`,`varbinary` ) VALUES ("
+    + "'a','abc','tiny text','medium text','text','long text',"
+    + "-1, 1, -2, 2, -3, 3,"
+    + "-4, 4, -5, 5,"
+    + "1.1, 2.2, 123,"
+    + "'2015-10-21','2015-10-21 11:22:33','2015-10-21 11:22:33','11:22:33','2016',"
+    + "'abc','abc','abc','abc',"
+    + "'1','2',true,"
+    + "'1','2')")
+    try dbManager.query("SELECT * FROM all_data_types LIMIT 1")
+    let results = try dbManager.storeResults()
+    defer { results.close() }
+    while let row = results.next() {
+    print(row)
+    }
+    
+    try dbManager.query("DELETE FROM all_data_types")
+    
+    
+    let stmt1 = MySQLStmt(dbManager.db)
+    defer { stmt1.close() }
+    let prepRes = stmt1.prepare("INSERT INTO all_data_types VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)")
+    //        print(prepRes)
+    stmt1.bindParam("a")
+    stmt1.bindParam("abc")
+    stmt1.bindParam("tiny text")
+    stmt1.bindParam("medium text")
+    stmt1.bindParam("text")
+    stmt1.bindParam("long text")
+    stmt1.bindParam(-1)
+    stmt1.bindParam(1)
+    stmt1.bindParam(-2)
+    stmt1.bindParam(2)
+    stmt1.bindParam(-3)
+    stmt1.bindParam(3)
+    stmt1.bindParam(-4)
+    stmt1.bindParam(4)
+    stmt1.bindParam(-5)
+    stmt1.bindParam(5)
+    stmt1.bindParam(1.1)
+    stmt1.bindParam(2.2)
+    stmt1.bindParam(123)
+    stmt1.bindParam("2015-10-21")
+    stmt1.bindParam("2015-10-21 11:22:33")
+    stmt1.bindParam("2015-10-21 11:22:33")
+    stmt1.bindParam("11:22:33")
+    stmt1.bindParam("2016")
+    
+    stmt1.bindParam("tinyblob👻")
+    stmt1.bindParam("mediumblob")
+    stmt1.bindParam("blob")
+    stmt1.bindParam("longblob")
+    //        "tinyblob".withCString { stmt1.bindParam($0, length: 8) }
+    //        "mediumblob".withCString { stmt1.bindParam($0, length: 10) }
+    //        "blob".withCString { stmt1.bindParam($0, length: 4) }
+    //        "longblob".withCString { stmt1.bindParam($0, length: 8) }
+    stmt1.bindParam("1")
+    stmt1.bindParam("2")
+    stmt1.bindParam(1)
+    stmt1.bindParam("1")
+    stmt1.bindParam("2")
+    let execRes = stmt1.execute()
+    //        print(execRes)
+    let stmt2 = MySQLStmt(dbManager.db)
+    defer { stmt2.close() }
+    //        let prepRes2 = stmt2.prepare("SELECT `text`, 'blob' FROM all_data_types")
+    let prepRes2 = stmt2.prepare("SELECT * FROM all_data_types")
+    //        print(prepRes2)
+    let execRes2 = stmt2.execute()
+    let results2 = stmt2.results()
+    defer { results2.close() }
+    results2.forEachRow { row in
+    //            print("text", UTF8Encoding.encode(row[0] as! [UInt8]))
+    //            print("blob", row[1] as! String)
+    
+    print("char", row[0] as! String)
+    print("varchar", row[1] as! String)
+    print("tinytext", UTF8Encoding.encode(row[2] as! [UInt8]))
+    print("mediumtext", UTF8Encoding.encode(row[3] as! [UInt8]))
+    print("text", UTF8Encoding.encode(row[4] as! [UInt8]))
+    print("longtext", UTF8Encoding.encode(row[5] as! [UInt8]))
+    print("tinyint", row[6] as! Int8)
+    print("utinyint", row[7] as! UInt8)
+    print("smallint", row[8] as! Int16)
+    print("usmallint", row[9] as! UInt16)
+    print("mediumint", row[10] as! Int32)
+    print("umediumint", row[11] as! UInt32)
+    print("int", row[12] as! Int32)
+    print("uint", row[13] as! UInt32)
+    print("bigint", row[14] as! Int64)
+    print("ubigint", row[15] as! UInt64)
+    print("float", row[16] as! Float)
+    print("double", row[17] as! Double)
+    print("decimal", row[18] as! String)
+    print("date", row[19] as! String)
+    print("datetime", row[20] as! String)
+    print("timestamp", row[21] as! String)
+    print("time", row[22] as! String)
+    print("year", row[23] as! String)
+    print("tinyblob", UTF8Encoding.encode(row[24] as! [UInt8]))
+    print("mediumblob", UTF8Encoding.encode(row[25] as! [UInt8]))
+    print("blob", UTF8Encoding.encode(row[26] as! [UInt8]))
+    print("longblob", UTF8Encoding.encode(row[27] as! [UInt8]))
+    print("enum", row[28] as! String)
+    print("set", row[29] as! String)
+    print("bool", row[30] as! Int8)
+    print("binary", row[31] as! String)
+    print("varbinary", row[32] as! String)
+    }
+*/
 }
 
 

--- a/Connectors/MySQL/MySQLTests/MySQLTests.swift
+++ b/Connectors/MySQL/MySQLTests/MySQLTests.swift
@@ -40,9 +40,11 @@ class MySQLTests: XCTestCase {
 
         //  connect and select DB
         mysql = MySQL()
+        XCTAssert(mysql.setOption(.MYSQL_SET_CHARSET_NAME, "utf8mb4"), mysql.errorMessage())
         XCTAssert(mysql.connect(HOST, user: USER, password: PASSWORD), mysql.errorMessage())
         if mysql.selectDatabase(SCHEMA) == false {
             XCTAssert(mysql.query("CREATE SCHEMA `\(SCHEMA)` DEFAULT CHARACTER SET utf8mb4"), mysql.errorMessage())
+            XCTAssert(mysql.selectDatabase(SCHEMA), mysql.errorMessage())
         }
     }
     
@@ -87,56 +89,22 @@ class MySQLTests: XCTestCase {
 	}
 	
 	func testListDbs1() {
-		
-		let mysql = MySQL()
-		let res = mysql.connect(HOST, user: USER, password: PASSWORD)
-		
-		XCTAssert(res)
-		
-		if !res {
-			print(mysql.errorMessage())
-		}
-		
 		let list = mysql.listDatabases()
 		
 		XCTAssert(list.count > 0)
 		
 		print(list)
-		
-		mysql.close()
 	}
 	
 	func testListDbs2() {
-		
-		let mysql = MySQL()
-		let res = mysql.connect(HOST, user: USER, password: PASSWORD)
-		
-		XCTAssert(res)
-		
-		if !res {
-			print(mysql.errorMessage())
-		}
-		
 		let list = mysql.listDatabases("information_%")
 		
 		XCTAssert(list.count > 0)
 		
 		print(list)
-		
-		mysql.close()
 	}
 	
 	func testListTables1() {
-		
-		let mysql = MySQL()
-		let res = mysql.connect(HOST, user: USER, password: PASSWORD)
-		
-		XCTAssert(res)
-		
-		if !res {
-			print(mysql.errorMessage())
-		}
-		
 		let sres = mysql.selectDatabase("information_schema")
 		
 		XCTAssert(sres == true)
@@ -146,21 +114,9 @@ class MySQLTests: XCTestCase {
 		XCTAssert(list.count > 0)
 		
 		print(list)
-		
-		mysql.close()
 	}
 	
 	func testListTables2() {
-		
-		let mysql = MySQL()
-		let res = mysql.connect(HOST, user: USER, password: PASSWORD)
-		
-		XCTAssert(res)
-		
-		if !res {
-			print(mysql.errorMessage())
-		}
-		
 		let sres = mysql.selectDatabase("information_schema")
 		
 		XCTAssert(sres == true)
@@ -170,27 +126,11 @@ class MySQLTests: XCTestCase {
 		XCTAssert(list.count > 0)
 		
 		print(list)
-		
-		mysql.close()
 	}
 	
 	func testQuery1() {
-		let mysql = MySQL()
-		defer {
-			mysql.close()
-		}
-		
-		let res = mysql.connect(HOST, user: USER, password: PASSWORD)
-		XCTAssert(res)
-		
-		if !res {
-			print(mysql.errorMessage())
-			return
-		}
-		
-		let sres = mysql.selectDatabase(SCHEMA)
-		XCTAssert(sres == true)
-		
+        mysql.query("DROP TABLE IF EXISTS test")
+
 		let qres = mysql.query("CREATE TABLE test (id INT, d DOUBLE, s VARCHAR(1024))")
 		XCTAssert(qres == true, mysql.errorMessage())
 		
@@ -222,21 +162,8 @@ class MySQLTests: XCTestCase {
 	}
 	
 	func testQuery2() {
-		let mysql = MySQL()
-		defer {
-			mysql.close()
-		}
-		
-		let res = mysql.connect(HOST, user: USER, password: PASSWORD)
-		XCTAssert(res)
-		
-		if !res {
-			print(mysql.errorMessage())
-		}
-		
-		let sres = mysql.selectDatabase(SCHEMA)
-		XCTAssert(sres == true)
-		
+        mysql.query("DROP TABLE IF EXISTS test")
+
 		let qres = mysql.query("CREATE TABLE test (id INT, d DOUBLE, s VARCHAR(1024))")
 		XCTAssert(qres == true, mysql.errorMessage())
 		
@@ -268,30 +195,13 @@ class MySQLTests: XCTestCase {
 	}
 	
 	func testQueryStmt1() {
-		let mysql = MySQL()
-		defer {
-			mysql.close()
-		}
-		
-		let res = mysql.connect(HOST, user: USER, password: PASSWORD)
-		XCTAssert(res)
-		
-		if !res {
-			print(mysql.errorMessage())
-		}
-		
-		let sres = mysql.selectDatabase(SCHEMA)
-		XCTAssert(sres == true)
-		
 		mysql.query("DROP TABLE IF EXISTS all_data_types")
 		
 		let qres = mysql.query("CREATE TABLE `all_data_types` (`varchar` VARCHAR( 20 ),\n`tinyint` TINYINT,\n`text` TEXT,\n`date` DATE,\n`smallint` SMALLINT,\n`mediumint` MEDIUMINT,\n`int` INT,\n`bigint` BIGINT,\n`float` FLOAT( 10, 2 ),\n`double` DOUBLE,\n`decimal` DECIMAL( 10, 2 ),\n`datetime` DATETIME,\n`timestamp` TIMESTAMP,\n`time` TIME,\n`year` YEAR,\n`char` CHAR( 10 ),\n`tinyblob` TINYBLOB,\n`tinytext` TINYTEXT,\n`blob` BLOB,\n`mediumblob` MEDIUMBLOB,\n`mediumtext` MEDIUMTEXT,\n`longblob` LONGBLOB,\n`longtext` LONGTEXT,\n`enum` ENUM( '1', '2', '3' ),\n`set` SET( '1', '2', '3' ),\n`bool` BOOL,\n`binary` BINARY( 20 ),\n`varbinary` VARBINARY( 20 ) ) ENGINE = MYISAM")
 		XCTAssert(qres == true, mysql.errorMessage())
 		
 		let stmt1 = MySQLStmt(mysql)
-		defer {
-			stmt1.close()
-		}
+		defer { stmt1.close() }
 		let prepRes = stmt1.prepare("INSERT INTO all_data_types VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)")
 		XCTAssert(prepRes, stmt1.errorMessage())
 		XCTAssert(stmt1.paramCount() == 28)
@@ -334,28 +244,10 @@ class MySQLTests: XCTestCase {
 			
 			let execRes = stmt1.execute()
 			XCTAssert(execRes, "\(stmt1.errorCode()) \(stmt1.errorMessage()) - \(mysql.errorCode()) \(mysql.errorMessage())")
-			
-			stmt1.close()
 		}
 	}
 	
 	func testQueryStmt2() {
-		let mysql = MySQL()
-		defer {
-			mysql.close()
-		}
-		
-		mysql.setOption(.MYSQL_SET_CHARSET_NAME, "utf8mb4")
-		let res = mysql.connect(HOST, user: USER, password: PASSWORD)
-		XCTAssert(res)
-		
-		if !res {
-			print(mysql.errorMessage())
-		}
-		
-		let sres = mysql.selectDatabase(SCHEMA)
-		XCTAssert(sres == true)
-		
 		mysql.query("DROP TABLE IF EXISTS all_data_types")
 		
 		let qres = mysql.query("CREATE TABLE `all_data_types` (`varchar` VARCHAR( 20 ),\n`tinyint` TINYINT,\n`text` TEXT,\n`date` DATE,\n`smallint` SMALLINT,\n`mediumint` MEDIUMINT,\n`int` INT,\n`bigint` BIGINT,\n`ubigint` BIGINT UNSIGNED,\n`float` FLOAT( 10, 2 ),\n`double` DOUBLE,\n`decimal` DECIMAL( 10, 2 ),\n`datetime` DATETIME,\n`timestamp` TIMESTAMP,\n`time` TIME,\n`year` YEAR,\n`char` CHAR( 10 ),\n`tinyblob` TINYBLOB,\n`tinytext` TINYTEXT,\n`blob` BLOB,\n`mediumblob` MEDIUMBLOB,\n`mediumtext` MEDIUMTEXT,\n`longblob` LONGBLOB,\n`longtext` LONGTEXT,\n`enum` ENUM( '1', '2', '3' ),\n`set` SET( '1', '2', '3' ),\n`bool` BOOL,\n`binary` BINARY( 20 ),\n`varbinary` VARBINARY( 20 ) ) ENGINE = MYISAM")
@@ -363,9 +255,7 @@ class MySQLTests: XCTestCase {
 		
 		for _ in 1...2 {
 			let stmt1 = MySQLStmt(mysql)
-			defer {
-				stmt1.close()
-			}
+            defer { stmt1.close() }
 			let prepRes = stmt1.prepare("INSERT INTO all_data_types VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)")
 			XCTAssert(prepRes, stmt1.errorMessage())
 			XCTAssert(stmt1.paramCount() == 29)
@@ -404,13 +294,12 @@ class MySQLTests: XCTestCase {
 				
 				let execRes = stmt1.execute()
 				XCTAssert(execRes, "\(stmt1.errorCode()) \(stmt1.errorMessage()) - \(mysql.errorCode()) \(mysql.errorMessage())")
-				
-				stmt1.close()
 			}
 		}
 		
 		do {
 			let stmt1 = MySQLStmt(mysql)
+            defer { stmt1.close() }
 			
 			let prepRes = stmt1.prepare("SELECT * FROM all_data_types")
 			XCTAssert(prepRes, stmt1.errorMessage())
@@ -419,6 +308,7 @@ class MySQLTests: XCTestCase {
 			XCTAssert(execRes, stmt1.errorMessage())
 			
 			let results = stmt1.results()
+            defer { results.close() }
 			
 			let ok = results.forEachRow {
 				e in
@@ -457,24 +347,10 @@ class MySQLTests: XCTestCase {
                 XCTAssertEqual(e[28] as? String, "1")
 			}
 			XCTAssert(ok, stmt1.errorMessage())
-			
-			results.close()
-			stmt1.close()
 		}
 	}
 	
 	func testServerVersion() {
-		let mysql = MySQL()
-		defer {
-			mysql.close()
-		}
-		let res = mysql.connect(HOST, user: USER, password: PASSWORD)
-		XCTAssert(res)
-		
-		if !res {
-			print(mysql.errorMessage())
-		}
-		
 		let vers = mysql.serverVersion()
 		XCTAssert(vers >= 50627) // YMMV
 	}
@@ -771,163 +647,4 @@ class MySQLTests: XCTestCase {
             XCTAssertEqual(row[5] as? String, "-3.3")
         }
     }
-
-    /*
-    try dbManager.query("CREATE TABLE IF NOT EXISTS `all_data_types` (`char` CHAR( 10 ),`varchar` VARCHAR( 20 ),`tinytext` TINYTEXT,`mediumtext` MEDIUMTEXT,`text` TEXT,`longtext` LONGTEXT,"
-    + "`tinyint` TINYINT,`utinyint` TINYINT UNSIGNED,`smallint` SMALLINT,`usmallint` SMALLINT UNSIGNED,`mediumint` MEDIUMINT,`umediumint` MEDIUMINT UNSIGNED,"
-    + "`int` INT,`uint` INT UNSIGNED,`bigint` BIGINT,`ubigint` BIGINT UNSIGNED,"
-    + "`float` FLOAT( 10, 2 ),`double` DOUBLE,`decimal` DECIMAL( 10, 2 ),"
-    + "`date` DATE,`datetime` DATETIME,`timestamp` TIMESTAMP,`time` TIME,`year` YEAR,"
-    + "`tinyblob` TINYBLOB,`mediumblob` MEDIUMBLOB,`blob` BLOB,`longblob` LONGBLOB,"
-    + "`enum` ENUM( '1', '2', '3' ),`set` SET( '1', '2', '3' ),`bool` BOOL,"
-    + "`binary` BINARY( 20 ),`varbinary` VARBINARY( 20 ) )")
-    
-    try dbManager.query("DELETE FROM all_data_types")
-    
-    try dbManager.query("INSERT INTO all_data_types (`char`,`varchar`,`tinytext`,`mediumtext`,`text`,`longtext`,"
-    + "`tinyint`,`utinyint`,`smallint`,`usmallint`,`mediumint`,`umediumint`,"
-    + "`int`,`uint`,`bigint`,`ubigint`,"
-    + "`float`, `double`, `decimal`,"
-    + "`date`, `datetime`, `timestamp`, `time`,`year`,"
-    + "`tinyblob`, `mediumblob`, `blob`,`longblob`,"
-    + "`enum`,`set`,`bool`,"
-    + "`binary`,`varbinary` ) VALUES ("
-    + "'a','abc','tiny text','medium text','text','long text',"
-    + "-1, 1, -2, 2, -3, 3,"
-    + "-4, 4, -5, 5,"
-    + "1.1, 2.2, 123,"
-    + "'2015-10-21','2015-10-21 11:22:33','2015-10-21 11:22:33','11:22:33','2016',"
-    + "'abc','abc','abc','abc',"
-    + "'1','2',true,"
-    + "'1','2')")
-    try dbManager.query("SELECT * FROM all_data_types LIMIT 1")
-    let results = try dbManager.storeResults()
-    defer { results.close() }
-    while let row = results.next() {
-    print(row)
-    }
-    
-    try dbManager.query("DELETE FROM all_data_types")
-    
-    
-    let stmt1 = MySQLStmt(dbManager.db)
-    defer { stmt1.close() }
-    let prepRes = stmt1.prepare("INSERT INTO all_data_types VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)")
-    //        print(prepRes)
-    stmt1.bindParam("a")
-    stmt1.bindParam("abc")
-    stmt1.bindParam("tiny text")
-    stmt1.bindParam("medium text")
-    stmt1.bindParam("text")
-    stmt1.bindParam("long text")
-    stmt1.bindParam(-1)
-    stmt1.bindParam(1)
-    stmt1.bindParam(-2)
-    stmt1.bindParam(2)
-    stmt1.bindParam(-3)
-    stmt1.bindParam(3)
-    stmt1.bindParam(-4)
-    stmt1.bindParam(4)
-    stmt1.bindParam(-5)
-    stmt1.bindParam(5)
-    stmt1.bindParam(1.1)
-    stmt1.bindParam(2.2)
-    stmt1.bindParam(123)
-    stmt1.bindParam("2015-10-21")
-    stmt1.bindParam("2015-10-21 11:22:33")
-    stmt1.bindParam("2015-10-21 11:22:33")
-    stmt1.bindParam("11:22:33")
-    stmt1.bindParam("2016")
-    
-    stmt1.bindParam("tinyblob👻")
-    stmt1.bindParam("mediumblob")
-    stmt1.bindParam("blob")
-    stmt1.bindParam("longblob")
-    //        "tinyblob".withCString { stmt1.bindParam($0, length: 8) }
-    //        "mediumblob".withCString { stmt1.bindParam($0, length: 10) }
-    //        "blob".withCString { stmt1.bindParam($0, length: 4) }
-    //        "longblob".withCString { stmt1.bindParam($0, length: 8) }
-    stmt1.bindParam("1")
-    stmt1.bindParam("2")
-    stmt1.bindParam(1)
-    stmt1.bindParam("1")
-    stmt1.bindParam("2")
-    let execRes = stmt1.execute()
-    //        print(execRes)
-    let stmt2 = MySQLStmt(dbManager.db)
-    defer { stmt2.close() }
-    //        let prepRes2 = stmt2.prepare("SELECT `text`, 'blob' FROM all_data_types")
-    let prepRes2 = stmt2.prepare("SELECT * FROM all_data_types")
-    //        print(prepRes2)
-    let execRes2 = stmt2.execute()
-    let results2 = stmt2.results()
-    defer { results2.close() }
-    results2.forEachRow { row in
-    //            print("text", UTF8Encoding.encode(row[0] as! [UInt8]))
-    //            print("blob", row[1] as! String)
-    
-    print("char", row[0] as! String)
-    print("varchar", row[1] as! String)
-    print("tinytext", UTF8Encoding.encode(row[2] as! [UInt8]))
-    print("mediumtext", UTF8Encoding.encode(row[3] as! [UInt8]))
-    print("text", UTF8Encoding.encode(row[4] as! [UInt8]))
-    print("longtext", UTF8Encoding.encode(row[5] as! [UInt8]))
-    print("tinyint", row[6] as! Int8)
-    print("utinyint", row[7] as! UInt8)
-    print("smallint", row[8] as! Int16)
-    print("usmallint", row[9] as! UInt16)
-    print("mediumint", row[10] as! Int32)
-    print("umediumint", row[11] as! UInt32)
-    print("int", row[12] as! Int32)
-    print("uint", row[13] as! UInt32)
-    print("bigint", row[14] as! Int64)
-    print("ubigint", row[15] as! UInt64)
-    print("float", row[16] as! Float)
-    print("double", row[17] as! Double)
-    print("decimal", row[18] as! String)
-    print("date", row[19] as! String)
-    print("datetime", row[20] as! String)
-    print("timestamp", row[21] as! String)
-    print("time", row[22] as! String)
-    print("year", row[23] as! String)
-    print("tinyblob", UTF8Encoding.encode(row[24] as! [UInt8]))
-    print("mediumblob", UTF8Encoding.encode(row[25] as! [UInt8]))
-    print("blob", UTF8Encoding.encode(row[26] as! [UInt8]))
-    print("longblob", UTF8Encoding.encode(row[27] as! [UInt8]))
-    print("enum", row[28] as! String)
-    print("set", row[29] as! String)
-    print("bool", row[30] as! Int8)
-    print("binary", row[31] as! String)
-    print("varbinary", row[32] as! String)
-    }
-*/
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/Connectors/MySQL/MySQLTests/MySQLTests.swift
+++ b/Connectors/MySQL/MySQLTests/MySQLTests.swift
@@ -442,8 +442,37 @@ class MySQLTests: XCTestCase {
 		XCTAssert(vers >= 50627) // YMMV
 	}
 	
-	
-	
+    func testQueryInt() {
+        let mysql = MySQL()
+        defer {
+            mysql.close()
+        }
+        let res = mysql.connect(HOST, user: USER, password: PASSWORD)
+        XCTAssert(res)
+        if !res {
+            print(mysql.errorMessage())
+        }
+
+        let sres = mysql.selectDatabase(SCHEMA)
+        XCTAssert(sres == true)
+
+        let qres = mysql.query("CREATE TABLE IF NOT EXISTS int_test (a TINYINT, au TINYINT UNSIGNED, b SMALLINT, bu SMALLINT UNSIGNED, c MEDIUMINT, cu MEDIUMINT UNSIGNED, d INT, du INT UNSIGNED, e BIGINT, eu BIGINT UNSIGNED)")
+        XCTAssert(qres == true, mysql.errorMessage())
+
+        let qres2 = mysql.query("INSERT INTO int_test (a, au, b, bu, c, cu, d, du, e, eu) VALUES (-1, 1, -2, 2, -3, 3, -4, 4, -5, 5)")
+        XCTAssert(qres2 == true, mysql.errorMessage())
+        
+        let qres3 =  mysql.query("SELECT * FROM int_test")
+        XCTAssert(qres3 == true, mysql.errorMessage())
+
+        let results = mysql.storeResults()
+        if let results = results {
+            defer { results.close() }
+            while let row = results.next() {
+                print(row)
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
MySQL Connector is fine for OSX. 
But it has bug on ubuntu. The bug is related to integer type.

I fix integer type bug in this PR.

sample code is below.
```
let mysql =  MySQL()
mysql.connect(host, user: user, password: password, db: db)
mysql.query("CREATE TABLE IF NOT EXISTS testtest (a TINYINT, au TINYINT UNSIGNED, b SMALLINT, bu SMALLINT UNSIGNED, c MEDIUMINT, cu MEDIUMINT UNSIGNED, d INT, du INT UNSIGNED, e BIGINT, eu BIGINT UNSIGNED)")
mysql.query("INSERT INTO testtest (a, au, b, bu, c, cu, d, du, e, eu) VALUES (-1, 1, -2, 2, -3, 3, -4, 4, -5, 5)")

let stmt = MySQLStmt(dbManager.db)
defer { stmt.close() }
let prepRes = stmt.prepare("SELECT * FROM testtest LIMIT 1")
let execRes = stmt.execute()
let results = stmt.results()
defer { results.close() }
results.forEachRow { row in
    print(row)
}
```

wrong result
```
[Optional(139771882220799), Optional(139771882220545), Optional(139771882242046), Optional(139771882176514), Optional(139775415681021), Optional(139771120713731), Optional(139775415681020), Optional(139771120713732), Optional(18446744073709551611), Optional(5)]
```

correct result
```
[Optional(-1), Optional(1), Optional(-2), Optional(2), Optional(-3), Optional(3), Optional(-4), Optional(4), Optional(-5), Optional(5)]
```