### PR TITLE
Make MongoClient init throwable and call close() inside deinits of mongo classes

### DIFF
--- a/Connectors/MongoDB/BSON.swift
+++ b/Connectors/MongoDB/BSON.swift
@@ -63,6 +63,10 @@ public class BSON: CustomStringConvertible {
 	init(rawBson: UnsafeMutablePointer<bson_t>) {
 		self.doc = rawBson
 	}
+    
+    deinit {
+        close()
+    }
 
 	public func close() {
 		if self.doc != nil {

--- a/Connectors/MongoDB/MongoClient.swift
+++ b/Connectors/MongoDB/MongoClient.swift
@@ -41,14 +41,22 @@ public enum MongoResult {
 	}
 }
 
+public enum MongoClientError: ErrorType {
+    case InitError(String)
+}
+
 public class MongoClient {
 
 	var ptr: COpaquePointer
 
 	public typealias Result = MongoResult
 
-	public init(uri: String) {
+	public init(uri: String) throws {
 		self.ptr = mongoc_client_new(uri)
+        
+        if ptr == nil {
+            throw MongoClientError.InitError("Could not parse URI '\(uri)'")
+        }
 	}
 
 	public func close() {
@@ -58,12 +66,12 @@ public class MongoClient {
 		}
 	}
 
-	public func getCollection(databaseName: String, collectionName: String) -> MongoCollection {
-		return MongoCollection(client: self, databaseName: databaseName, collectionName: collectionName)
+	public func getCollection(databaseName: String, collectionName: String) throws -> MongoCollection {
+		return try MongoCollection(client: self, databaseName: databaseName, collectionName: collectionName)
 	}
 
-	public func getDatabase(databaseName: String) -> MongoDatabase {
-		return MongoDatabase(client: self, databaseName: databaseName)
+	public func getDatabase(databaseName: String) throws -> MongoDatabase {
+		return try MongoDatabase(client: self, databaseName: databaseName)
 	}
 
 	public func serverStatus() -> Result {

--- a/Connectors/MongoDB/MongoClient.swift
+++ b/Connectors/MongoDB/MongoClient.swift
@@ -70,7 +70,7 @@ public class MongoClient {
 		}
 	}
 
-	public func getCollection(databaseName: String, collectionName: String) throws -> MongoCollection {
+	public func getCollection(databaseName: String, collectionName: String) -> MongoCollection {
 		return MongoCollection(client: self, databaseName: databaseName, collectionName: collectionName)
 	}
 

--- a/Connectors/MongoDB/MongoClient.swift
+++ b/Connectors/MongoDB/MongoClient.swift
@@ -58,6 +58,10 @@ public class MongoClient {
             throw MongoClientError.InitError("Could not parse URI '\(uri)'")
         }
 	}
+    
+    deinit {
+        close()
+    }
 
 	public func close() {
 		if self.ptr != nil {

--- a/Connectors/MongoDB/MongoClient.swift
+++ b/Connectors/MongoDB/MongoClient.swift
@@ -41,14 +41,22 @@ public enum MongoResult {
 	}
 }
 
+public enum MongoClientError: ErrorType {
+    case InitError(String)
+}
+
 public class MongoClient {
 
 	var ptr: COpaquePointer
 
 	public typealias Result = MongoResult
 
-	public init(uri: String) {
+	public init(uri: String) throws {
 		self.ptr = mongoc_client_new(uri)
+        
+        if ptr == nil {
+            throw MongoClientError.InitError("Could not parse URI '\(uri)'")
+        }
 	}
     
     deinit {
@@ -63,7 +71,7 @@ public class MongoClient {
 	}
 
 	public func getCollection(databaseName: String, collectionName: String) throws -> MongoCollection {
-		return try MongoCollection(client: self, databaseName: databaseName, collectionName: collectionName)
+		return MongoCollection(client: self, databaseName: databaseName, collectionName: collectionName)
 	}
 
 	public func getDatabase(databaseName: String) -> MongoDatabase {

--- a/Connectors/MongoDB/MongoClient.swift
+++ b/Connectors/MongoDB/MongoClient.swift
@@ -41,22 +41,14 @@ public enum MongoResult {
 	}
 }
 
-public enum MongoClientError: ErrorType {
-    case InitError(String)
-}
-
 public class MongoClient {
 
 	var ptr: COpaquePointer
 
 	public typealias Result = MongoResult
 
-	public init(uri: String) throws {
+	public init(uri: String) {
 		self.ptr = mongoc_client_new(uri)
-        
-        if ptr == nil {
-            throw MongoClientError.InitError("Could not parse URI '\(uri)'")
-        }
 	}
     
     deinit {
@@ -74,8 +66,8 @@ public class MongoClient {
 		return try MongoCollection(client: self, databaseName: databaseName, collectionName: collectionName)
 	}
 
-	public func getDatabase(databaseName: String) throws -> MongoDatabase {
-		return try MongoDatabase(client: self, databaseName: databaseName)
+	public func getDatabase(databaseName: String) -> MongoDatabase {
+		return MongoDatabase(client: self, databaseName: databaseName)
 	}
 
 	public func serverStatus() -> Result {

--- a/Connectors/MongoDB/MongoCollection.swift
+++ b/Connectors/MongoDB/MongoCollection.swift
@@ -243,6 +243,10 @@ public class MongoCollection {
 	init(rawPtr: COpaquePointer) {
 		self.ptr = rawPtr
 	}
+    
+    deinit {
+        close()
+    }
 
 	public func close() {
 		if self.ptr != nil {

--- a/Connectors/MongoDB/MongoCollection.swift
+++ b/Connectors/MongoDB/MongoCollection.swift
@@ -101,10 +101,6 @@ public enum MongoRemoveFlag: Int {
 	}
 }
 
-public enum MongoCollectionError: ErrorType {
-    case InitError(String)
-}
-
 public class MongoIndexOptionsGeo {
 	var rawOpt = UnsafeMutablePointer<mongoc_index_opt_geo_t>.alloc(1)
 
@@ -233,11 +229,8 @@ public class MongoCollection {
 
 	public typealias Result = MongoResult
 
-	public init(client: MongoClient, databaseName: String, collectionName: String) throws {
+	public init(client: MongoClient, databaseName: String, collectionName: String) {
 		self.ptr = mongoc_client_get_collection(client.ptr, databaseName, collectionName)
-        if ptr == nil {
-            throw MongoCollectionError.InitError("Could not access collection '\(collectionName)' of database '\(databaseName)'.")
-        }
 	}
 
 	init(rawPtr: COpaquePointer) {

--- a/Connectors/MongoDB/MongoCollection.swift
+++ b/Connectors/MongoDB/MongoCollection.swift
@@ -101,6 +101,10 @@ public enum MongoRemoveFlag: Int {
 	}
 }
 
+public enum MongoCollectionError: ErrorType {
+    case InitError(String)
+}
+
 public class MongoIndexOptionsGeo {
 	var rawOpt = UnsafeMutablePointer<mongoc_index_opt_geo_t>.alloc(1)
 
@@ -229,8 +233,11 @@ public class MongoCollection {
 
 	public typealias Result = MongoResult
 
-	public init(client: MongoClient, databaseName: String, collectionName: String) {
+	public init(client: MongoClient, databaseName: String, collectionName: String) throws {
 		self.ptr = mongoc_client_get_collection(client.ptr, databaseName, collectionName)
+        if ptr == nil {
+            throw MongoCollectionError.InitError("Could not access collection '\(collectionName)' of database '\(databaseName)'.")
+        }
 	}
 
 	init(rawPtr: COpaquePointer) {

--- a/Connectors/MongoDB/MongoCursor.swift
+++ b/Connectors/MongoDB/MongoCursor.swift
@@ -32,6 +32,10 @@ public class MongoCursor {
 	init(rawPtr: COpaquePointer) {
 		self.ptr = rawPtr
 	}
+    
+    deinit {
+        close()
+    }
 
 	public func close() {
 		if self.ptr != nil {

--- a/Connectors/MongoDB/MongoDatabase.swift
+++ b/Connectors/MongoDB/MongoDatabase.swift
@@ -41,6 +41,10 @@ public class MongoDatabase {
             throw MongoDatabaseError.InitError("Could not access database '\(databaseName)'")
         }
 	}
+    
+    deinit {
+        close()
+    }
 
 	public func close() {
 		if self.ptr != nil {
@@ -70,9 +74,13 @@ public class MongoDatabase {
 		return .ReplyCollection(MongoCollection(rawPtr: col))
 	}
 
-	public func getCollection(collectionName: String) -> MongoCollection {
+	public func getCollection(collectionName: String) throws -> MongoCollection {
 		let col = mongoc_database_get_collection(self.ptr, collectionName)
-		return MongoCollection(rawPtr: col)
+        if col != nil {
+            return MongoCollection(rawPtr: col)
+        } else {
+            throw MongoCollectionError.InitError("Could not access collection '\(collectionName)'.")
+        }
 	}
 
 	public func collectionNames() -> [String] {

--- a/Connectors/MongoDB/MongoDatabase.swift
+++ b/Connectors/MongoDB/MongoDatabase.swift
@@ -25,21 +25,14 @@
 
 import libmongoc
 
-public enum MongoDatabaseError: ErrorType {
-    case InitError(String)
-}
-
 public class MongoDatabase {
 
 	var ptr: COpaquePointer
 
 	public typealias Result = MongoResult
 
-	public init(client: MongoClient, databaseName: String) throws {
+	public init(client: MongoClient, databaseName: String) {
 		self.ptr = mongoc_client_get_database(client.ptr, databaseName)
-        if ptr == nil {
-            throw MongoDatabaseError.InitError("Could not access database '\(databaseName)'")
-        }
 	}
     
     deinit {
@@ -74,13 +67,9 @@ public class MongoDatabase {
 		return .ReplyCollection(MongoCollection(rawPtr: col))
 	}
 
-	public func getCollection(collectionName: String) throws -> MongoCollection {
+	public func getCollection(collectionName: String) -> MongoCollection {
 		let col = mongoc_database_get_collection(self.ptr, collectionName)
-        if col != nil {
-            return MongoCollection(rawPtr: col)
-        } else {
-            throw MongoCollectionError.InitError("Could not access collection '\(collectionName)'.")
-        }
+        return MongoCollection(rawPtr: col)
 	}
 
 	public func collectionNames() -> [String] {

--- a/Connectors/MongoDB/MongoDatabase.swift
+++ b/Connectors/MongoDB/MongoDatabase.swift
@@ -25,14 +25,21 @@
 
 import libmongoc
 
+public enum MongoDatabaseError: ErrorType {
+    case InitError(String)
+}
+
 public class MongoDatabase {
 
 	var ptr: COpaquePointer
 
 	public typealias Result = MongoResult
 
-	public init(client: MongoClient, databaseName: String) {
+	public init(client: MongoClient, databaseName: String) throws {
 		self.ptr = mongoc_client_get_database(client.ptr, databaseName)
+        if ptr == nil {
+            throw MongoDatabaseError.InitError("Could not access database '\(databaseName)'")
+        }
 	}
 
 	public func close() {


### PR DESCRIPTION
Most MongoDB classes seem to be currently leaking memory unless `close()` is called