### PR TITLE
encode UInt value to json

### DIFF
--- a/PerfectLib/JSONConvertible.swift
+++ b/PerfectLib/JSONConvertible.swift
@@ -150,6 +150,12 @@ extension Int: JSONConvertible {
 	}
 }
 
+extension UInt: JSONConvertible {
+	public func jsonEncodedString() throws -> String {
+		return String(self)
+    }
+}
+
 extension Double: JSONConvertible {
 	public func jsonEncodedString() throws -> String {
 		return String(self)
@@ -187,6 +193,8 @@ func jsonEncodedStringWorkAround(o: Any) throws -> String {
 	case let jsonAble as String:
 		return try jsonAble.jsonEncodedString()
 	case let jsonAble as Int:
+		return try jsonAble.jsonEncodedString()
+	case let jsonAble as UInt:
 		return try jsonAble.jsonEncodedString()
 	case let jsonAble as Double:
 		return try jsonAble.jsonEncodedString()


### PR DESCRIPTION
UInt can not encode to json.
If use MySQL and create table with unsigned int primary key, value obtained from table is UInt.
this PR fix to encode UInt value.