### PR TITLE
make abandoned session also deleted in SQLite DB./Fix  JSON-Encode issue./Fix Firefox-WebSocket issue.

### DIFF
--- a/PerfectLib/JSONConvertible.swift
+++ b/PerfectLib/JSONConvertible.swift
@@ -202,6 +202,8 @@ func jsonEncodedStringWorkAround(o: Any) throws -> String {
 		return try jsonAble.jsonEncodedString()
 	case let jsonAble as [Any]:
 		return try jsonAble.jsonEncodedString()
+	case let jsonAble as [[String:Any]]:
+		return try jsonAble.jsonEncodedString()
 	case let jsonAble as [String:Any]:
 		return try jsonAble.jsonEncodedString()
 	default:

--- a/PerfectLib/SessionManager.swift
+++ b/PerfectLib/SessionManager.swift
@@ -218,7 +218,17 @@ public class SessionManager {
 	func getNowSeconds() -> Double {
 		return Double(ICU.icuDateToSeconds(ICU.getNow()))
 	}
-	
+
+	func abandon() throws {
+		//delete this session
+		let fullKey = self.configuration.name + ":" + self.configuration.id
+		let encoded = try JSONEncoder().encode(self.dictionary!)
+		let sqlite = try SQLite(PerfectServer.staticPerfectServer.homeDir() + serverSQLiteDBs + perfectSessionDB)
+		defer { sqlite.close() }
+
+		try sqlite.execute("DELETE FROM sessions where session_key = '\(fullKey)'")
+	}
+
 	func commit() throws {
 		// save values
 		let fullKey = self.configuration.name + ":" + self.configuration.id

--- a/PerfectLib/WebResponse.swift
+++ b/PerfectLib/WebResponse.swift
@@ -163,6 +163,11 @@ public class WebResponse {
 	
 	/// Discards a previously started session. The session will not be propagated and any changes to the session's variables will be discarded.
 	public func abandonSession(named: String) {
+		do {
+			try self.sessions[named]?.abandon()
+		} catch let e{
+			LogManager.logMessage("Exception while abandoning session \(named) \(e)")
+		}
 		self.sessions.removeValueForKey(named)
 	}
 	

--- a/PerfectLib/WebSocketHandler.swift
+++ b/PerfectLib/WebSocketHandler.swift
@@ -289,7 +289,7 @@ public class WebSocketHandler : RequestHandler {
 			connection = request.header("Connection"),
 			secWebSocketKey = request.header("Sec-WebSocket-Key"),
 			secWebSocketVersion = request.header("Sec-WebSocket-Version")
-			where upgrade.lowercaseString == "websocket" && connection.lowercaseString == "upgrade" else {
+			where upgrade.lowercaseString == "websocket" && connection.lowercaseString.contains("upgrade") else {
 
 				response.setStatus(400, message: "Bad Request")
 				response.requestCompletedCallback()


### PR DESCRIPTION
Hi @kjessup.
     I am using Perfect framework in my project and debugged to found the current implementation of WebResponse.abandonSession() function only remove the SessionManager object from its member dictionary, didn't update any session values changed before abandon calls to SQLite DB, even not delete the entire session in SQLite DB. 
     I think this is a bug, and make this pull request. 
     Please review it.

Signed-off-by: wuqiong <memccpy@gmail.com>