### PR TITLE
cURL fixes

### DIFF
--- a/Sources/PerfectLib/cURL.swift
+++ b/Sources/PerfectLib/cURL.swift
@@ -79,7 +79,7 @@ public class CURL {
 	#else
 		let opaqueMe = UnsafeMutablePointer<Void>(Unmanaged.passUnretained(self).toOpaque())
 	#endif
-	#if Ubuntu_14_04
+	#if os(Linux)
 		setOption(CURLOPT_WRITEHEADER, v: opaqueMe)
 		setOption(CURLOPT_FILE, v: opaqueMe)
 		setOption(CURLOPT_INFILE, v: opaqueMe)

--- a/Sources/PerfectLib/cURL.swift
+++ b/Sources/PerfectLib/cURL.swift
@@ -165,8 +165,8 @@ public class CURL {
 		if perf.0 == false { // done
 			closure(perf.1, header.data, body.data)
 		} else {
-			Threading.dispatchBlock { [weak self] in
-				self?.performInner(header, body: body, closure: closure)
+			Threading.dispatchBlock {
+				self.performInner(header, body: body, closure: closure)
 			}
 		}
 	}


### PR DESCRIPTION
Unavailable #if Ubuntu_14_04 (swift 3.0 with SPM) doesn't let PerfectLib compile, replaced with generic #if os(Linux), which is safe since CURLOPT_WRITEHEADER is actually defined CURLOPT_HEADERDATA on newer. [weak self] is removed from performInner since self will be always passed as nil and therefore never callback.