### PR TITLE
Fixed an error where mustache partials would fail to include

### DIFF
--- a/Sources/PerfectLib/Mustache.swift
+++ b/Sources/PerfectLib/Mustache.swift
@@ -223,8 +223,8 @@ public class MustacheEvaluationContext {
 	}
 	
 	func getCurrentFilePath() -> String? {
-		if self.templateName != nil {
-			return self.templateName!
+		if self.templateName != nil && self.templatePath != nil {
+			return self.templatePath!
 		}
 		if self.parent != nil {
 			return self.parent!.getCurrentFilePath()


### PR DESCRIPTION
Fixed an error where mustache partials would fail to include property because the getCurrentFilePath() method would only retrieve the template name instead of the full file path. 