### PR TITLE
Readme Main Banner Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Perfect: Server-Side Swift
-![Perfect logo](http://www.perfect.org/images/perfect-git-banner.png)
+[![Perfect logo](http://www.perfect.org/images/perfect-git-banner.png)](http://perfect.org/get-involved.html)
 
 [![Swift 3.0](https://img.shields.io/badge/Swift-3.0-orange.svg?style=flat)](https://developer.apple.com/swift/)
 [![Platforms OS X | Linux](https://img.shields.io/badge/Platforms-OS%20X%20%7C%20Linux%20-lightgray.svg?style=flat)](https://developer.apple.com/swift/)


### PR DESCRIPTION
Updates readme with link syntax for the get involved banner so that it hyperlinks to http://perfect.org/get-involved.html instead of the image itself