### PR TITLE
Added Int32 & Int64 Extensions (Plus Unsigned)

### DIFF
--- a/Sources/PerfectLib/JSONConvertible.swift
+++ b/Sources/PerfectLib/JSONConvertible.swift
@@ -180,6 +180,34 @@ extension UInt: JSONConvertible {
     }
 }
 
+extension Int32: JSONConvertible {
+    /// Convert an Int into JSON text.
+    public func jsonEncodedString() throws -> String {
+        return String(self)
+    }
+}
+
+extension Int64: JSONConvertible {
+    /// Convert an Int into JSON text.
+    public func jsonEncodedString() throws -> String {
+        return String(self)
+    }
+}
+
+extension UInt32: JSONConvertible {
+    /// Convert an Int into JSON text.
+    public func jsonEncodedString() throws -> String {
+        return String(self)
+    }
+}
+
+extension UInt64: JSONConvertible {
+    /// Convert an Int into JSON text.
+    public func jsonEncodedString() throws -> String {
+        return String(self)
+    }
+}
+
 extension Double: JSONConvertible {
     /// Convert a Double into JSON text.
     public func jsonEncodedString() throws -> String {


### PR DESCRIPTION
Added Extensions for Uint32, UInt64, Int32, & Int64 so that those types do not fail when converting to string with jsonEncodedString()