### PR TITLE
Updated access control for methods in JSONConvertibleObject

### DIFF
--- a/Sources/PerfectLib/JSONConvertible.swift
+++ b/Sources/PerfectLib/JSONConvertible.swift
@@ -75,11 +75,11 @@ open class JSONConvertibleObject: JSONConvertible {
     /// Default initializer.
     public init() {}
     /// Get the JSON keys/value.
-    public func setJSONValues(_ values:[String:Any]) {}
+    open func setJSONValues(_ values:[String:Any]) {}
     /// Set the object properties based on the JSON keys/values.
-    public func getJSONValues() -> [String:Any] { return [String:Any]() }
+    open func getJSONValues() -> [String:Any] { return [String:Any]() }
     /// Encode the object into JSON text
-    public func jsonEncodedString() throws -> String {
+    open func jsonEncodedString() throws -> String {
         return try self.getJSONValues().jsonEncodedString()
     }
 }


### PR DESCRIPTION
Updated JSON methods in JSONConvertibleObject to be `open` so that they can be overwritten by subclasses.

A corresponding jira bug has also been created:
http://jira.perfect.org:8080/browse/ISS-255