### PR TITLE
Returned public access for default initializer into JSONConvertibleObject 

### DIFF
--- a/Sources/PerfectLib/JSONConvertible.swift
+++ b/Sources/PerfectLib/JSONConvertible.swift
@@ -73,7 +73,7 @@ public protocol JSONConvertible {
 /// Base for a custom object which can be converted to and from JSON.
 open class JSONConvertibleObject: JSONConvertible {
     /// Default initializer.
-    open init() {}
+    public init() {}
     /// Get the JSON keys/value.
     open func setJSONValues(_ values:[String:Any]) {}
     /// Set the object properties based on the JSON keys/values.


### PR DESCRIPTION
Only classes and overridable class members can be declared 'open'