### PR TITLE
Replaced [String] dependency url with [Package.Dependency]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,10 +19,10 @@
 
 import PackageDescription
 
-var urls = [String]()
+var dependencies = Array<Package.Dependency>()
 
 #if os(Linux)
-urls += ["https://github.com/PerfectlySoft/Perfect-LinuxBridge.git"]
+dependencies += [.Package(url: "https://github.com/PerfectlySoft/Perfect-LinuxBridge.git", majorVersion: 2)]
 #else
 
 #endif
@@ -30,6 +30,6 @@ urls += ["https://github.com/PerfectlySoft/Perfect-LinuxBridge.git"]
 let package = Package(
 	name: "PerfectLib",
 	targets: [],
-	dependencies: urls.map { .Package(url: $0, majorVersion: 2) },
+	dependencies: dependencies,
 	exclude: []
 )


### PR DESCRIPTION
The problem with [String] urls was that inside the Package
specification, we were running a map function that was inserting
major version 2 for all the URLS. This is not the best way to deal 
although we only have 1 dependency at the moment.

Reason: What if in some near future we add 1 more dependency?
Will that dependency also take 2 as major version? Likely not.

Solution: The current approach adds the ability to add fully
satisfied dependency without the explicit knowledge of mapping over.