### PR TITLE
Make "No such file or directory" errors more descriptive

### DIFF
--- a/Sources/PerfectLib/File.swift
+++ b/Sources/PerfectLib/File.swift
@@ -241,7 +241,7 @@ public extension File {
 		let openFd = Darwin.open(internalPath, CInt(mode.toMode), permissions.rawValue)
 	#endif
 		guard openFd != -1 else {
-			try ThrowFileError()
+			try ThrowFileError(file: internalPath)
 		}
 		fd = Int(openFd)
 	}


### PR DESCRIPTION
Previously, "No such file or directory" errors would point to this line in this file, i.e.
`fileError(2, "No such file or directory /Users/[redacted]/Desktop/Programming/Swift/Perfect/[redacted]/Core/.build/checkouts/PerfectLib.git-3712999737848873669/Sources/PerfectLib/File.swift open(_:permissions:) 245")`
This change will replace that error with:
`fileError(2, "No such file or directory /Users/[redacted]/Desktop/Programming/Swift/Perfect/[redacted]/log/log.log open(_:permissions:) 244")`