### PR TITLE
Fix Swift 4.1 bugs

### DIFF
--- a/Sources/PerfectLib/Dir.swift
+++ b/Sources/PerfectLib/Dir.swift
@@ -146,7 +146,7 @@ public struct Dir {
 
 		var ent = dirent()
 		let entPtr = UnsafeMutablePointer<UnsafeMutablePointer<dirent>?>.allocate(capacity:  1)
-		defer { entPtr.deallocate(capacity: 1) }
+		defer { entPtr.deallocate() }
 
 		while readDir(dir, &ent, entPtr) == 0 && entPtr.pointee != nil {
 			let name = ent.d_name

--- a/Sources/PerfectLib/File.swift
+++ b/Sources/PerfectLib/File.swift
@@ -573,7 +573,7 @@ public final class TemporaryFile: File {
         let fd = mkstemp(name)
         let tmpFileName = String(validatingUTF8: name)!
 
-        name.deallocate(capacity: utf8.count + 1)
+        name.deallocate()
 
         self.init(tmpFileName, fd: fd)
     }

--- a/Sources/PerfectLib/SysProcess.swift
+++ b/Sources/PerfectLib/SysProcess.swift
@@ -55,7 +55,7 @@ public class SysProcess {
 
 		defer {
 			cArgs.deinitialize(count: cArgsCount + 2)
-			cArgs.deallocate(capacity: cArgsCount + 2)
+			cArgs.deallocate()
 		}
 
 		cArgs[0] = strdup(cmd)
@@ -68,7 +68,10 @@ public class SysProcess {
 		let cEnvCount = env?.count ?? 0
 		let cEnv = UnsafeMutablePointer<maybeCChar>.allocate(capacity: cEnvCount + 1)
 
-		defer { cEnv.deinitialize(count: cEnvCount + 1) ; cEnv.deallocate(capacity: cEnvCount + 1) }
+		defer {
+            cEnv.deinitialize(count: cEnvCount + 1)
+            cEnv.deallocate()
+        }
 
 		cEnv[cEnvCount] = nil
 		for idx in 0..<cEnvCount {

--- a/Sources/PerfectLib/Utilities.swift
+++ b/Sources/PerfectLib/Utilities.swift
@@ -458,7 +458,7 @@ public func formatDate(_ date: Double, format: String, timezone inTimezone: Stri
 	let maxResults = 1024
 	let results = UnsafeMutablePointer<Int8>.allocate(capacity:  maxResults)
 	defer {
-		results.deallocate(capacity: maxResults)
+		results.deallocate()
 	}
 	let res = strftime(results, maxResults, format, &t)
 	if res > 0 {

--- a/Sources/PerfectLib/Utilities.swift
+++ b/Sources/PerfectLib/Utilities.swift
@@ -422,7 +422,7 @@ extension String {
 		guard count >= str.count else {
 			return false
 		}
-		return str.begins(with: self[index(endIndex, offsetBy: -str.count)..<endIndex])
+		return str.begins(with: String(self[index(endIndex, offsetBy: -str.count)..<endIndex]))
 	}
 }
 
@@ -600,9 +600,9 @@ extension String {
 			if noTrailsIndex == startIndex {
 				return self
 			}
-			return self[startIndex..<noTrailsIndex]
+			return String(self[startIndex..<noTrailsIndex])
 		}
-		return self[startIndex..<endIndex]
+		return String(self[startIndex..<endIndex])
 	}
 	
 	public var filePathExtension: String {
@@ -612,7 +612,7 @@ extension String {
 		guard endIndex != startIndex else {
 			return ""
 		}
-		return self[index(after: endIndex)..<noTrailsIndex]
+		return String(self[index(after: endIndex)..<noTrailsIndex])
 	}
 	
 	public var resolvingSymlinksInFilePath: String {

--- a/Tests/PerfectLibTests/PerfectLibTests.swift
+++ b/Tests/PerfectLibTests/PerfectLibTests.swift
@@ -463,21 +463,6 @@ class PerfectLibTests: XCTestCase {
 		XCTAssert(res == src)
 	}
 
-	func testSubstringTo() {
-
-		let src = "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ"
-		let res = src.substring(to: src.index(src.startIndex, offsetBy: 5))
-
-		XCTAssert(res == "ABCDE")
-	}
-
-	func testSubstringWith() {
-
-		let src = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-		let range = src.index(src.startIndex, offsetBy: 3)..<src.index(src.startIndex, offsetBy: 6)
-		XCTAssert("DEF" == src.substring(with: range))
-	}
-
 	func testStringBeginsWith() {
 		let a = "123456"
 
@@ -663,8 +648,6 @@ extension PerfectLibTests {
 			("testStringByReplacingString", testStringByReplacingString),
 			("testStringByReplacingString2", testStringByReplacingString2),
 			("testStringByReplacingString3", testStringByReplacingString3),
-			("testSubstringTo", testSubstringTo),
-			("testSubstringWith", testSubstringWith),
 
 			("testDeletingPathExtension", testDeletingPathExtension),
 			("testGetPathExtension", testGetPathExtension),


### PR DESCRIPTION
Added three commits to remove errors and warnings when using Swift 4.1.
Fixes issue #257.