### PR TITLE
Fallback to String if trying to decode a number that overflows the Int max range

### DIFF
--- a/Sources/PerfectLib/JSONConvertible.swift
+++ b/Sources/PerfectLib/JSONConvertible.swift
@@ -611,7 +611,7 @@ private class JSONDecodeState {
                 if needPeriod && needExp {
                     return Int(s) ?? s
                 }
-                return Double(s) ?? s
+                return Double(s)!
             } else {
                 break
             }

--- a/Sources/PerfectLib/JSONConvertible.swift
+++ b/Sources/PerfectLib/JSONConvertible.swift
@@ -609,9 +609,9 @@ private class JSONDecodeState {
             } else if last.isDigit() {
                 pushBack = c
                 if needPeriod && needExp {
-                    return Int(s)! ?? s
+                    return Int(s) ?? s
                 }
-                return Double(s)!
+                return Double(s) ?? s
             } else {
                 break
             }

--- a/Sources/PerfectLib/JSONConvertible.swift
+++ b/Sources/PerfectLib/JSONConvertible.swift
@@ -609,7 +609,7 @@ private class JSONDecodeState {
             } else if last.isDigit() {
                 pushBack = c
                 if needPeriod && needExp {
-                    return Int(s)!
+                    return Int(s)! ?? s
                 }
                 return Double(s)!
             } else {


### PR DESCRIPTION
This change decodes numbers that overflow the Int rage as String